### PR TITLE
Dockerfile for building an avancedb server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:jessie
+
+RUN apt-get update
+RUN apt-get install -y curl wget unzip bzip2 pkgconf
+RUN apt-get install -y g++ make autoconf autoconf2.13 automake libtool git libboost-all-dev zlib1g-dev
+
+ADD LICENSE Makefile README.md /AvanceDB/
+ADD externals/ /AvanceDB/externals/
+ADD scripts/ /AvanceDB/scripts/
+ADD src/ /AvanceDB/src/
+
+WORKDIR /AvanceDB
+
+RUN SHELL=/bin/bash make -j2 CONF=Release
+
+EXPOSE 5994
+
+WORKDIR /AvanceDB/src/avancedb/dist/Release/GNU-Linux-x86
+ENTRYPOINT ./avancedb
+


### PR DESCRIPTION
## Problem

Currently, binaries need to be built for every platform, which may not be convenient. There are plans to release packages for major linux distros, but that will also take some effort.

## Solution

Provide a `Dockerfile` so it is easy to build and publish (in docker hub or similar) a prebuilt AvanceDB server.

## How it works

**Building:**
After cloning with submodules:

```
docker build . -t avancedb
```

This will create a docker image named `avances` which exposes port `5994`

**Running:**
This will run the AvanceDB container, mapping `5994` in the container to the CouchdDB standard port `5984`. The container will run on foreground and can be killed by `CTRL`+`C`.
```
docker run --rm -it -p 5984:5994 avancedb
```